### PR TITLE
chore(prettier): update eslint config for prettier package

### DIFF
--- a/packages/rollup-plugin/.eslintrc.js
+++ b/packages/rollup-plugin/.eslintrc.js
@@ -14,9 +14,6 @@ module.exports = {
     "plugin:jest/recommended",
     "plugin:jest/style",
     "prettier",
-    "prettier/@typescript-eslint",
-    "prettier/unicorn",
-    "prettier/prettier",
   ],
   rules: {
     "unicorn/no-null": "off",

--- a/packages/transform/.eslintrc.js
+++ b/packages/transform/.eslintrc.js
@@ -14,9 +14,6 @@ module.exports = {
     "plugin:jest/recommended",
     "plugin:jest/style",
     "prettier",
-    "prettier/@typescript-eslint",
-    "prettier/unicorn",
-    "prettier/prettier",
   ],
   rules: {
     "unicorn/no-null": "off",

--- a/packages/transform/tests/test.ts
+++ b/packages/transform/tests/test.ts
@@ -112,7 +112,9 @@ describe("lodash transforms", () => {
     };
 
     if (expectedOutput === UNCHANGED) {
+      // eslint-disable-next-line jest/no-conditional-expect
       expect(output.cjs).toBeNull();
+      // eslint-disable-next-line jest/no-conditional-expect
       expect(output.es).toBeNull();
     } else {
       for (const key of ["cjs", "es"] as const) {

--- a/packages/transform/tests/test.ts
+++ b/packages/transform/tests/test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-conditional-expect */
 import * as acorn from "acorn";
 
 import { CodeWithSourcemap, transform, UNCHANGED } from "../src";
@@ -112,9 +113,7 @@ describe("lodash transforms", () => {
     };
 
     if (expectedOutput === UNCHANGED) {
-      // eslint-disable-next-line jest/no-conditional-expect
       expect(output.cjs).toBeNull();
-      // eslint-disable-next-line jest/no-conditional-expect
       expect(output.es).toBeNull();
     } else {
       for (const key of ["cjs", "es"] as const) {


### PR DESCRIPTION
The prettier eslint package has been throwing in CI due to changes in their rulesets.