### PR TITLE
fix: add .js to import for mjs/swc compat

### DIFF
--- a/packages/transform/src/lodash-specifiers-to-cjs.ts
+++ b/packages/transform/src/lodash-specifiers-to-cjs.ts
@@ -15,6 +15,6 @@ export function lodashSpecifiersToCjs(
     ({ imported, local }) =>
       `import ${
         imported.name !== local.name ? local.name : imported.name
-      } from "${base}/${imported.name}";`
+      } from "${base}/${imported.name}.js";`
   );
 }


### PR DESCRIPTION
NextJS 12 / SWC bail out unless the transformed lodash imports include the `.js` extension.