### PR TITLE
Improve `output.format` conditions

### DIFF
--- a/.changeset/lucky-masks-complain.md
+++ b/.changeset/lucky-masks-complain.md
@@ -1,0 +1,5 @@
+---
+"@optimize-lodash/rollup-plugin": minor
+---
+
+Support `esm` and `module` formats. (Thanks @antixrist !)

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -92,7 +92,7 @@ Default: `false`
 
 If `true`, the plugin will rewrite _lodash_ imports to use _lodash-es_.
 
-_Note: the build will fail if your Rollup output format is not also set to `es`!_
+_Note: the build will fail if your Rollup output format is not also set to `es`, `esm`, or `module`!_
 
 ### `appendDotJs`
 

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -28,6 +28,8 @@ export type OptimizeLodashOptions = {
 
 const UNCHANGED = null;
 
+const ROLLUP_ESM_FORMATS = new Set(["es", "esm", "module"]);
+
 /**
  * Converts lodash imports to be specific, enabling better tree-shaking:
  *
@@ -40,7 +42,7 @@ const UNCHANGED = null;
  *
  * Optionally, set `useLodashEs` to true and `lodash` imports will be converted to `lodash-es`
  * imports. Note that it's up to user to include the `lodash-es` module and ensure the output
- * is set to some form of `es` (other output formats will error). An example:
+ * is set to some form of `es`/`esm`/`module` (other output formats will error). An example:
  *
  * `import { isNil } from "lodash";` -> `import { isNil } from "lodash-es";`
  *
@@ -56,12 +58,15 @@ export function optimizeLodashImports({
   appendDotJs,
 }: OptimizeLodashOptions = {}): Plugin & Required<Pick<Plugin, "transform">> {
   const filter = createFilter(include, exclude);
-  const esmFormats = ['es', 'esm', 'module'];
-  
+
   return {
     name: "optimize-lodash-imports",
     outputOptions(options) {
-      if (useLodashEs && options.format && !esmFormats.includes(options.format)) {
+      if (
+        useLodashEs &&
+        options.format &&
+        !ROLLUP_ESM_FORMATS.has(options.format)
+      ) {
         this.error(
           `'useLodashEs' is true but the output format is not 'es', 'esm' or 'module', it's ${
             options.format ?? "undefined"

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -56,13 +56,14 @@ export function optimizeLodashImports({
   appendDotJs,
 }: OptimizeLodashOptions = {}): Plugin & Required<Pick<Plugin, "transform">> {
   const filter = createFilter(include, exclude);
-
+  const esmFormats = ['es', 'esm', 'module'];
+  
   return {
     name: "optimize-lodash-imports",
     outputOptions(options) {
-      if (useLodashEs && options.format !== "es") {
+      if (useLodashEs && options.format && !esmFormats.includes(options.format)) {
         this.error(
-          `'useLodashEs' is true but the output format is not 'es', it's ${
+          `'useLodashEs' is true but the output format is not 'es', 'esm' or 'module', it's ${
             options.format ?? "undefined"
           }`
         );

--- a/packages/rollup-plugin/tests/rollup.test.ts
+++ b/packages/rollup-plugin/tests/rollup.test.ts
@@ -43,7 +43,7 @@ describe("rollup", () => {
     await expect(
       wrapperRollupGenerate(STANDARD_AND_FP, { useLodashEs: true }, "cjs")
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"'useLodashEs' is true but the output format is not 'es', it's cjs"`
+      `'useLodashEs' is true but the output format is not 'es', 'esm' or 'module', it's cjs"`
     );
   });
 

--- a/packages/rollup-plugin/tests/rollup.test.ts
+++ b/packages/rollup-plugin/tests/rollup.test.ts
@@ -43,7 +43,7 @@ describe("rollup", () => {
     await expect(
       wrapperRollupGenerate(STANDARD_AND_FP, { useLodashEs: true }, "cjs")
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `'useLodashEs' is true but the output format is not 'es', 'esm' or 'module', it's cjs"`
+      `"'useLodashEs' is true but the output format is not 'es', 'esm' or 'module', it's cjs"`
     );
   });
 


### PR DESCRIPTION
Rollup's `output.format` option has aliases for `es` value - `esm` and `module`
https://github.com/rollup/rollup/blob/a2b42f0/docs/999-big-list-of-options.md#outputformat