### PR TITLE
feat: add an ESM shim for the rollup plugin

### DIFF
--- a/.changeset/ten-crabs-hang.md
+++ b/.changeset/ten-crabs-hang.md
@@ -1,0 +1,5 @@
+---
+"@optimize-lodash/rollup-plugin": major
+---
+
+Support importing as ESM. CJS is still supported and this _should_ be backwards compatible, however this is being treated as a breaking change due to dropping 'main' in package.json ('exports' replaces it).

--- a/.changeset/ten-crabs-hang.md
+++ b/.changeset/ten-crabs-hang.md
@@ -2,4 +2,4 @@
 "@optimize-lodash/rollup-plugin": major
 ---
 
-Support importing as ESM. CJS is still supported and this _should_ be backwards compatible, however this is being treated as a breaking change due to dropping 'main' in package.json ('exports' replaces it).
+Support importing as ESM. CJS is still supported and this _should_ be backwards compatible, however this is being treated as a breaking change due to dropping 'main' in package.json ('exports' replaces it). The actual value of this is fairly low since ESM can import CommonJS.

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -14,7 +14,10 @@
     "type": "git",
     "url": "https://github.com/kyle-johnson/rollup-plugin-optimize-lodash-imports.git"
   },
-  "main": "dist/index.js",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -32,7 +35,7 @@
     "lint": "eslint .",
     "test": "jest",
     "test:ci": "jest --coverage --ci",
-    "build": "rm -rf dist && tsc -p tsconfig.dist.json",
+    "build": "rm -rf dist && tsc -p tsconfig.dist.json && gen-esm-wrapper ./dist ./dist/index.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "depcheck": "depcheck"
@@ -62,6 +65,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-jest": "27.1.4",
     "eslint-plugin-unicorn": "43.0.2",
+    "gen-esm-wrapper": "1.1.3",
     "jest": "29.2.2",
     "lodash": "4.17.21",
     "prettier": "2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ importers:
       eslint-config-prettier: 8.5.0
       eslint-plugin-jest: 27.1.4
       eslint-plugin-unicorn: 43.0.2
+      gen-esm-wrapper: 1.1.3
       jest: 29.2.2
       lodash: 4.17.21
       prettier: 2.7.1
@@ -99,6 +100,7 @@ importers:
       eslint-config-prettier: 8.5.0_eslint@8.27.0
       eslint-plugin-jest: 27.1.4_mo2lami4yy66jkzk2pp2s2sft4
       eslint-plugin-unicorn: 43.0.2_eslint@8.27.0
+      gen-esm-wrapper: 1.1.3
       jest: 29.2.2_@types+node@12.20.55
       lodash: 4.17.21
       prettier: 2.7.1
@@ -1728,6 +1730,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /assert/1.5.0:
+    resolution: {integrity: sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==}
+    dependencies:
+      object-assign: 4.1.1
+      util: 0.10.3
+    dev: true
+
   /babel-jest/29.2.2_@babel+core@7.20.2:
     resolution: {integrity: sha512-kkq2QSDIuvpgfoac3WZ1OOcHsQQDU5xYk2Ql7tLdJ8BVAYbefEXal+NfS45Y5LVZA7cxC8KYcQMObpCt1J025w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2810,7 +2819,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.42.0_ofgjrzjuekeo7s3hdyz2yuzw34
       '@typescript-eslint/utils': 5.42.0_rmayb2veg2btbq6mbmnyivgasy
       eslint: 8.27.0
-      jest: 29.2.2_@types+node@10.17.60
+      jest: 29.2.2_@types+node@12.20.55
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3145,6 +3154,13 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
 
+  /gen-esm-wrapper/1.1.3:
+    resolution: {integrity: sha512-LNHZ+QpaCW/0VhABIbXn45V+P8kFvjjwuue9hbV23eOjuFVz6c0FE3z1XpLX9pSjLW7UmtCkXo5F9vhZWVs8oQ==}
+    hasBin: true
+    dependencies:
+      is-valid-identifier: 2.0.2
+    dev: true
+
   /generic-names/2.0.1:
     resolution: {integrity: sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==}
     dependencies:
@@ -3384,6 +3400,10 @@ packages:
       wrappy: 1.0.2
     dev: true
 
+  /inherits/2.0.1:
+    resolution: {integrity: sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==}
+    dev: true
+
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
@@ -3576,6 +3596,12 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
+
+  /is-valid-identifier/2.0.2:
+    resolution: {integrity: sha512-mpS5EGqXOwzXtKAg6I44jIAqeBfntFLxpAth1rrKbxtKyI6LPktyDYpHBI+tHlduhhX/SF26mFXmxQu995QVqg==}
+    dependencies:
+      assert: 1.5.0
     dev: true
 
   /is-weakref/1.0.2:
@@ -4524,6 +4550,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-key: 3.1.1
+    dev: true
+
+  /object-assign/4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /object-inspect/1.12.2:
@@ -5525,6 +5556,12 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
+    dev: true
+
+  /util/0.10.3:
+    resolution: {integrity: sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==}
+    dependencies:
+      inherits: 2.0.1
     dev: true
 
   /v8-to-istanbul/9.0.1:


### PR DESCRIPTION
The actual value of this is fairly low since ESM can import CommonJS, but this does drop `main` in `package.json` in favor of `exports` which _might_ be a breaking change for some users.