### PR TITLE
Support TypeScript "moduleResolution": "node16"

### DIFF
--- a/.changeset/three-news-float.md
+++ b/.changeset/three-news-float.md
@@ -1,0 +1,5 @@
+---
+"@optimize-lodash/rollup-plugin": patch
+---
+
+Support TypeScript `"moduleResolution": "node16"`.

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -17,7 +17,8 @@
   },
   "exports": {
     "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
With Typescript 5.1 and the following tsconfig:

```json
{
  "compilerOptions": {
    "strict": true,
    "moduleResolution": "node16"
  }
}
```

the rollup plugin fails to import types:

```ts
import { optimizeLodashImports } from "@optimize-lodash/rollup-plugin"
```

with this error:

> Could not find a declaration file for module '@optimize-lodash/rollup-plugin'. '/Users/semenov/tmp/ts/node_modules/.pnpm/@optimize-lodash+rollup-plugin@4.0.3_rollup@3.28.0/node_modules/@optimize-lodash/rollup-plugin/dist/index.mjs' implicitly has an 'any' type.
>
> There are types at '/Users/semenov/tmp/ts/node_modules/@optimize-lodash/rollup-plugin/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@optimize-lodash/rollup-plugin' library may need to update its package.json or typings.
> 
> ts(7016)

The fix add types compatible with modern moduleResolution.