### PR TITLE
fix: don't transform chain()

### DIFF
--- a/.changeset/cold-horses-joke.md
+++ b/.changeset/cold-horses-joke.md
@@ -1,0 +1,5 @@
+---
+"@optimize-lodash/esbuild-plugin": minor
+---
+
+Print warnings to console.error()

--- a/.changeset/shiny-planes-train.md
+++ b/.changeset/shiny-planes-train.md
@@ -1,0 +1,7 @@
+---
+"@optimize-lodash/transform": patch
+"@optimize-lodash/esbuild-plugin": patch
+"@optimize-lodash/rollup-plugin": patch
+---
+
+`chain()` is no longer tranformed because it cannot be imported except from the base import; a warning is printed when a matching import is found and the import is left as-is

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -104,7 +104,7 @@ export function testX(x) {
 }
 ```
 
-The above code will not be optimized, and Rollup will print a warning.
+The above code will not be optimized, and the plugin prints a warning.
 
 To avoid this, always import the specific method(s) you need:
 
@@ -116,6 +116,10 @@ export function testX(x) {
   return isNil(x);
 }
 ```
+
+### `chain()` cannot be optimized
+
+The `chain()` method from `lodash` cannot be successfully imported from `"lodash/chain"` without also importing from `"lodash"`. Imports which include `chain()` are _not modified_ and the plugin prints a warning.
 
 ## Alternatives
 

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -156,6 +156,10 @@ export function testX(x) {
 }
 ```
 
+### `chain()` cannot be optimized
+
+The `chain()` method from `lodash` cannot be successfully imported from `"lodash/chain"` without also importing from `"lodash"`. Imports which include `chain()` are _not modified_ and the plugin prints a warning.
+
 ## Alternatives
 
 [`babel-plugin-lodash`](https://www.npmjs.com/package/babel-plugin-lodash) solves the issue for CommonJS outputs and modifies default imports as well. However, it doesn't enable transparent `lodash-es` use and may not make sense for projects using [@rollup/plugin-typescript](https://www.npmjs.com/package/@rollup/plugin-typescript) which don't wish to add a Babel step.

--- a/packages/transform/tests/test.ts
+++ b/packages/transform/tests/test.ts
@@ -174,6 +174,8 @@ describe("lodash transforms", () => {
       [`import _ from "lodash";`, 1],
       [`import fp from "lodash/fp";`, 1],
       [`import * as lodash from "lodash";`, 1],
+      [`import { chain } from "lodash";`, 1],
+      [`import { chain as c } from "lodash";`, 1],
       // supported or no-op cases
       [`import { isNil } from "lodash/isNil";`, 0],
       [`import { isNil } from "lodash/isNil.js";`, 0],


### PR DESCRIPTION
Closes #444 

It's _possible_ this still works with lodash-es -- this needs testing before release (don't want to break that if it works).

Includes a small refactor to shift error handling up and make the happy-path top-level.